### PR TITLE
fixed a compatabilty issue in test_coordinates.py

### DIFF
--- a/test/test_coordinates.py
+++ b/test/test_coordinates.py
@@ -75,9 +75,9 @@ def test_float_parts_bitarray():
     assert mantissa_bits.count() == len(mantissa_bits)
 
     with pytest.raises(ValueError):
-        float_parts_bitarray(np.float128(1.0))
+        float_parts_bitarray(np.longdouble(1.0))
     with pytest.raises(ValueError):
-        float_parts_bitarray(np.float16(1.0))
+        float_parts_bitarray(np.half(1.0))
 
 
 def test_location_code_from_coordinate():


### PR DESCRIPTION
I replaced the numpy types float128 and float16 with their equivalent longdouble and half.
This change improves compatibility, because the type alias float128 only exists on some platforms.

The change to float16 is only for consistency.

For reference:
https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.float128

To underline my point, please assure yourself, that the two types are identical by running:
```
import numpy as np
assert np.float128 == np.longdouble
assert np.float16 == np.half
```