### PR TITLE
Fix `num_trailing_zeros = 0` in descriptor.py

### DIFF
--- a/src/dyada/descriptor.py
+++ b/src/dyada/descriptor.py
@@ -142,7 +142,7 @@ class RefinementDescriptor:
         num_trailing_zeros = 0
         while inverted_data[-num_trailing_zeros - 1] == 0:
             num_trailing_zeros += 1
-        inverted_data = inverted_data[:-num_trailing_zeros]
+        inverted_data = inverted_data[:None if num_trailing_zeros==0 else -num_trailing_zeros]
         return RefinementDescriptor.from_binary(num_dimensions, ~inverted_data)
 
     @staticmethod


### PR DESCRIPTION
Fixes an issue with `num_trailing_zeros = 0`, that would result in `inverted_data[0:-0]` which evaluates to the empty list `[]`.

For reference, see:
https://docs.python.org/3/reference/expressions.html#slicings

Possible alternatives:
```
inverted_data = inverted_data[:-num_trailing_zeros or None]
inverted_data = inverted_data[:length] if length != 0
inverted_data = inverted_data[:length] if length
```
